### PR TITLE
More efficient printer deletion

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,9 @@ function removePrinter(index){
     }else {
       localStorage.setItem("savedPrinters", JSON.stringify(printers));
     }
-    location.reload();
+    numPrinters = 0;
+    $("#printerGrid").empty();
+    reloadPrinters();
   }
 }
 


### PR DESCRIPTION
Printer panel is removed from the view instead of refreshing the page using location.reload()
